### PR TITLE
Fix: Center input paper area horizontally

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,38 @@
 ---
-name: Bug report
-about: Create a report to help us improve
+name: Relatório de bug
+about: Crie um relatório para nos ajudar a melhorar
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Descreva o bug**
+Uma descrição clara e concisa do que é o bug.
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**Para Reproduzir**
+Passos para reproduzir o comportamento:
+1. Vá para '...'
+2. Clique em '....'
+3. Role para baixo até '....'
+4. Veja o erro
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Comportamento esperado**
+Uma descrição clara e concisa do que você esperava que acontecesse.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Capturas de tela**
+Se aplicável, adicione capturas de tela para ajudar a explicar seu problema.
 
-**Desktop (please complete the following information):**
- - OS: [e.g. iOS]
- - Browser [e.g. chrome, safari]
- - Version [e.g. 22]
+**Desktop (por favor, complete as seguintes informações):**
+ - SO: [ex. iOS]
+ - Navegador [ex. chrome, safari]
+ - Versão [ex. 22]
 
-**Smartphone (please complete the following information):**
- - Device: [e.g. iPhone6]
- - OS: [e.g. iOS8.1]
- - Browser [e.g. stock browser, safari]
- - Version [e.g. 22]
+**Smartphone (por favor, complete as seguintes informações):**
+ - Dispositivo: [ex. iPhone6]
+ - SO: [ex. iOS8.1]
+ - Navegador [ex. navegador padrão, safari]
+ - Versão [ex. 22]
 
-**Additional context**
-Add any other context about the problem here.
+**Contexto adicional**
+Adicione qualquer outro contexto sobre o problema aqui.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,20 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Solicitação de funcionalidade
+about: Sugira uma ideia para este projeto
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Sua solicitação de funcionalidade está relacionada a um problema? Por favor, descreva.**
+Uma descrição clara e concisa do problema. Ex. Eu sempre fico frustrado quando [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Descreva a solução que você gostaria**
+Uma descrição clara e concisa do que você quer que aconteça.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Descreva as alternativas que você considerou**
+Uma descrição clara e concisa de quaisquer soluções ou funcionalidades alternativas que você considerou.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Contexto adicional**
+Adicione qualquer outro contexto ou capturas de tela sobre a solicitação de funcionalidade aqui.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,76 +1,76 @@
-# Contributor Covenant Code of Conduct
+# Código de Conduta do Pacto do Contribuinte
 
-## Our Pledge
+## Nosso Compromisso
 
-In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+No interesse de promover um ambiente aberto e acolhedor, nós, como
+contribuidores e mantenedores, comprometemo-nos a tornar a participação em nosso projeto e
+nossa comunidade uma experiência livre de assédio para todos, independentemente da idade, corpo
+tamanho, deficiência, etnia, características sexuais, identidade e expressão de gênero,
+nível de experiência, educação, status socioeconômico, nacionalidade, pessoal
+aparência, raça, religião ou identidade e orientação sexual.
 
-## Our Standards
+## Nossos Padrões
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Exemplos de comportamento que contribuem para a criação de um ambiente positivo
+incluem:
 
-- Using welcoming and inclusive language
-- Being respectful of differing viewpoints and experiences
-- Gracefully accepting constructive criticism
-- Focusing on what is best for the community
-- Showing empathy towards other community members
+- Usar linguagem acolhedora e inclusiva
+- Ser respeitoso com diferentes pontos de vista e experiências
+- Aceitar críticas construtivas com elegância
+- Focar no que é melhor para a comunidade
+- Demonstrar empatia para com outros membros da comunidade
 
-Examples of unacceptable behavior by participants include:
+Exemplos de comportamento inaceitável por parte dos participantes incluem:
 
-- The use of sexualized language or imagery and unwelcome sexual attention or
-  advances
-- Trolling, insulting/derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or electronic
-  address, without explicit permission
-- Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+- O uso de linguagem ou imagens sexualizadas e atenção ou
+  avanços sexuais indesejados
+- Trolling, comentários insultuosos/depreciativos e ataques pessoais ou políticos
+- Assédio público ou privado
+- Publicar informações privadas de terceiros, como um endereço físico ou eletrônico,
+  sem permissão explícita
+- Outra conduta que poderia razoavelmente ser considerada inadequada em um
+  ambiente profissional
 
-## Our Responsibilities
+## Nossas Responsabilidades
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Os mantenedores do projeto são responsáveis por esclarecer os padrões de comportamento
+aceitável e espera-se que tomem medidas corretivas apropriadas e justas em
+resposta a quaisquer instâncias de comportamento inaceitável.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Os mantenedores do projeto têm o direito e a responsabilidade de remover, editar ou
+rejeitar comentários, commits, código, edições de wiki, issues e outras contribuições
+que não estão alinhadas a este Código de Conduta, ou banir temporária ou
+permanentemente qualquer contribuidor por outros comportamentos que considerem inadequados,
+ameaçadores, ofensivos ou prejudiciais.
 
-## Scope
+## Escopo
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+Este Código de Conduta se aplica tanto dentro dos espaços do projeto quanto em espaços públicos
+quando um indivídu फादर representar o projeto ou sua comunidade. Exemplos de
+representação de um projeto ou comunidade incluem o uso de um endereço de e-mail oficial do projeto,
+postagem por meio de uma conta oficial de mídia social ou atuação como um representante nomeado
+em um evento online ou offline. A representação de um projeto pode ser posteriormente
+definida e esclarecida pelos mantenedores do projeto.
 
-## Enforcement
+## Aplicação
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at saurabhdaware99@gmail.com. All
-complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+Instâncias de comportamento abusivo, de assédio ou de outra forma inaceitável podem ser
+relatadas entrando em contato com a equipe do projeto em saurabhdaware99@gmail.com. <!-- TODO: Atualizar este endereço de e-mail para o contato do mantenedor atual do fork. --> Todas as
+reclamações serão revisadas e investigadas e resultarão em uma resposta que
+seja considerada necessária e apropriada às circunstâncias. A equipe do projeto é
+obrigada a manter a confidencialidade em relação ao relator de um incidente.
+Mais detalhes sobre políticas específicas de aplicação podem ser postados separadamente.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Os mantenedores do projeto que não seguem ou não aplicam o Código de Conduta de boa
+fé podem enfrentar repercussões temporárias ou permanentes, conforme determinado por outros
+membros da liderança do projeto.
 
-## Attribution
+## Atribuição
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+Este Código de Conduta é adaptado do [Pacto do Contribuinte][homepage], versão 1.4,
+disponível em https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see
+Para respostas a perguntas comuns sobre este código de conduta, consulte
 https://www.contributor-covenant.org/faq

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,27 @@
-# Contribution Guide 🌻
+# Guia de Contribuição 🌻
 
-The project is built with basic web setup (HTML, CSS, and JavaScript).
+O projeto é construído com uma configuração web básica (HTML, CSS e JavaScript).
 
-## 🐨 Local Setup
+## 🐨 Configuração Local
 
-- [Fork](https://github.com/saurabhdaware/text-to-handwriting/fork) this repository.
+- Faça um [Fork](https://github.com/saurabhdaware/text-to-handwriting/fork) deste repositório. <!-- TODO: Atualizar este link para apontar para o fork atual, se necessário. -->
 
-*Note: You need NodeJS installed in your machine to run formatter and server*
+*Observação: Você precisa do NodeJS instalado em sua máquina para rodar o formatador e o servidor*
 
 ```
-git clone https://github.com/:your-github-username/text-to-handwriting
+git clone https://github.com/:seu-nome-de-usuario-do-github/text-to-handwriting
 cd text-to-handwriting
 npm install
 npm run dev
 ```
 
-## 🤗 Hello First-time Contributors
+## 🤗 Olá Contribuidores de Primeira Viagem
 
-There are lot of resources (articles, courses, videos) available for getting started with git and GitHub you can search and follow any of the resource you like.
+Existem muitos recursos (artigos, cursos, vídeos) disponíveis para começar com git e GitHub; você pode pesquisar e seguir qualquer recurso que desejar.
 
-- You can pick any of the issues from [Issues](https://github.com/saurabhdaware/text-to-handwriting/issues) or If you feel like it needs extra feature or if you find bug, you can create your own issue.
-- You can drop a comment on issue saying "Hi Saurabh, let me work on this or I will kill you 🔪" to avoid multiple people working on the same PR.
+- Você pode escolher qualquer uma das issues em [Issues](https://github.com/saurabhdaware/text-to-handwriting/issues) <!-- TODO: Atualizar este link para apontar para as issues do fork atual, se necessário. --> ou, se sentir que precisa de um recurso extra ou se encontrar um bug, pode criar sua própria issue.
+- Você pode deixar um comentário na issue dizendo "Olá [mantenedor], deixe-me trabalhar nisso ou vou transformar seu café em descafeinado 🔪" para evitar que várias pessoas trabalhem na mesma PR.
 
-Lastly, It is fine if you mess something up. If there is anything wrong in the PR I will let you know how to fix that in comments of the PR.
+Por último, não há problema se você bagunçar algo. Se houver algo errado na PR, eu informarei como consertar nos comentários da PR.
 
-If you are still scared to drop a PR or need any help, you can always drop me a message on my [Twitter @saurabhcodes](https://twitter.com/saurabhcodes) or drop me an email at saurabhdaware99@gmail.com.
+Se você ainda estiver com receio de enviar uma PR ou precisar de ajuda, pode sempre me enviar uma mensagem no [Twitter do mantenedor] ou enviar um e-mail para [e-mail de contato do mantenedor]. <!-- TODO: Atualizar com os detalhes de contato do mantenedor atual. -->

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 <p align="center">
-<img alt="Text-to-handwriting title image" src="https://res.cloudinary.com/saurabhdaware/image/upload/w_400/v1586015094/saurabh2019/text-to-handwriting-title.png" /> 
-<br/><b><a href="https://saurabhdaware.github.io/text-to-handwriting/">https://saurabhdaware.github.io/text-to-handwriting/</a></b><br/><br/><img alt="NPM Version" src="https://img.shields.io/github/package-json/v/saurabhdaware/text-to-handwriting?style=for-the-badge&labelColor=black&logo=npm&color=darkred" /> <a href="#contributing"><img alt="Contributions Welcome" src="https://img.shields.io/badge/contributions-welcome-brightgreen?style=for-the-badge&labelColor=black&logo=github"></a> <br/><a href="https://github.com/saurabhdaware/text-to-handwriting/blob/master/LICENSE"> <img alt="GitHub License MIT" src="https://img.shields.io/github/license/saurabhdaware/text-to-handwriting?style=for-the-badge&labelColor=black&logo=github"> </a><a href="https://twitter.com/saurabhcodes"><img alt="Twitter Follow" src="https://img.shields.io/twitter/follow/saurabhcodes?style=for-the-badge&color=09f&labelColor=black&logo=twitter&label=@saurabhcodes"></a><br/><br/> I hate writing assignments so I made this tool that converts text to an image that looks like handwriting😛
+<img alt="Imagem de título Texto-para-Caligrafia" src="https://res.cloudinary.com/saurabhdaware/image/upload/w_400/v1586015094/saurabh2019/text-to-handwriting-title.png" /> 
+<br/><b><a href="https://saurabhdaware.github.io/text-to-handwriting/">https://saurabhdaware.github.io/text-to-handwriting/</a></b><br/> <!-- TODO: Atualizar este link para o link de demonstração do fork, se disponível. Atualmente, aponta para o projeto original. --> <br/><img alt="Versão NPM" src="https://img.shields.io/github/package-json/v/saurabhdaware/text-to-handwriting?style=for-the-badge&labelColor=black&logo=npm&color=darkred" /> <a href="#contribuindo"><img alt="Contribuições Bem-vindas" src="https://img.shields.io/badge/contributions-welcome-brightgreen?style=for-the-badge&labelColor=black&logo=github"></a> <br/><a href="https://github.com/saurabhdaware/text-to-handwriting/blob/master/LICENSE"> <img alt="Licença GitHub MIT" src="https://img.shields.io/github/license/saurabhdaware/text-to-handwriting?style=for-the-badge&labelColor=black&logo=github"> </a><a href="https://twitter.com/saurabhcodes"><img alt="Seguir no Twitter" src="https://img.shields.io/twitter/follow/saurabhcodes?style=for-the-badge&color=09f&labelColor=black&logo=twitter&label=@saurabhcodes"></a><br/><br/> Esta ferramenta converte texto em uma imagem que se assemelha à caligrafia 😛
 
 </p>
 
-*Note: This project is now archived. Read the announcement at https://github.com/saurabhdaware/text-to-handwriting/issues/138*
+## 🌠 Resultado
 
-## 🌠 Output
+<img width="400" alt="Imagem de exemplo do resultado" src="sample.jpeg" />
 
-<img width="400" alt="Sample image of output" src="sample.jpeg" />
+## 🤗 Contribuindo
 
-## 🤗 Contributing
+Confira o [Guia de Contribuição](CONTRIBUTING.md) para configuração local e guia de contribuição. <!-- TODO: Certifique-se de que CONTRIBUTING.pt-BR.md exista ou atualize o link -->
 
-Checkout [Contribution Guide](CONTRIBUTING.md) for local setup and contribution guide.
+## 📚 Bibliotecas utilizadas
 
-## 📚 Libraries used
-
-- [html2canvas](https://github.com/niklasvh/html2canvas) - Turns DOM into Canvas.
-- [jsPDF](https://github.com/MrRio/jsPDF) - To generate PDF from images.
-- [cypress](https://github.com/cypress-io/cypress) - Testing Library
-- [serve](https://github.com/zeit/serve) - Start local server
+- [html2canvas](https://github.com/niklasvh/html2canvas) - Transforma DOM em Canvas.
+- [jsPDF](https://github.com/MrRio/jsPDF) - Para gerar PDF a partir de imagens.
+- [cypress](https://github.com/cypress-io/cypress) - Biblioteca de Testes
+- [serve](https://github.com/zeit/serve) - Inicia servidor local
 
 ---
 
-[<img alt="Buy me a Coffee Button" width=200 src="https://c5.patreon.com/external/logo/become_a_patron_button.png">](https://www.patreon.com/bePatron?u=31891872) &nbsp; [<img alt="Buy me a Coffee Button" width=200 src="https://cdn.buymeacoffee.com/buttons/default-yellow.png">](https://www.buymeacoffee.com/saurabhdaware)
+[<!-- Links de patrocínio do mantenedor original. Revisar/Remover se necessário. -->]
+[<img alt="Botão Buy me a Coffee" width=200 src="https://c5.patreon.com/external/logo/become_a_patron_button.png">](https://www.patreon.com/bePatron?u=31891872) &nbsp; [<img alt="Botão Buy me a Coffee" width=200 src="https://cdn.buymeacoffee.com/buttons/default-yellow.png">](https://www.buymeacoffee.com/saurabhdaware)
+[<!-- Fim dos links de patrocínio. -->]
 
-Bye!
-Have fun 🦄
+Tchau!
+Divirta-se 🦄

--- a/css/index.css
+++ b/css/index.css
@@ -211,6 +211,8 @@ body.dark .github-corner {
   font-size: 10pt;
   position: relative;
   top: 0px;
+  margin-left: auto;
+  margin-right: auto;
   font-family: var(--handwriting-font);
   color: var(--ink-color);
   line-height: 1.5em;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="pt-BR">
   <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
@@ -25,27 +25,27 @@
     <meta name="theme-color" content="#09f" />
     <meta
       name="description"
-      content="I hate writing assignments so I made this tool that converts text to an image that looks like handwriting. You can copy paste text content into the textbox and click generate image button to generate image. Text to Handwriting"
+      content="Eu odeio fazer trabalhos escritos, então criei esta ferramenta que converte texto em uma imagem que parece caligrafia. Você pode copiar e colar o conteúdo do texto na caixa de texto e clicar no botão gerar imagem para gerar a imagem. Texto para Caligrafia"
     />
     <meta
       name="keywords"
-      content="text to handwriting, text-to-handwrting, saurabh text to handwriting, convert text to image, write assignment online"
+      content="texto para caligrafia, conversor de texto para caligrafia, saurabh texto para caligrafia, converter texto em imagem, escrever trabalho online"
     />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="author" content="Saurabh Daware" />
     <meta name="copyright" content="Saurabh Daware" />
     <meta name="robots" content="follow" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Text to Handwriting" />
+    <meta property="og:title" content="Texto para Caligrafia" />
     <meta
       property="og:url"
       content="https://saurabhdaware.github.io/text-to-handwriting"
     />
     <meta
       property="og:description"
-      content="I hate writing assignments so I made this tool that converts text to an image that looks like handwriting. You can copy paste text content into the textbox and click generate image button to generate image. Text to Handwriting"
+      content="Eu odeio fazer trabalhos escritos, então criei esta ferramenta que converte texto em uma imagem que parece caligrafia. Você pode copiar e colar o conteúdo do texto na caixa de texto e clicar no botão gerar imagem para gerar a imagem. Texto para Caligrafia"
     />
-    <meta property="og:site_name" content="Text to Handwriting" />
+    <meta property="og:site_name" content="Texto para Caligrafia" />
 
     <meta
       property="og:image:secure_url"
@@ -63,7 +63,7 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:creator" content="@saurabhcodes" />
 
-    <title>Text to Handwriting</title>
+    <title>Texto para Caligrafia</title>
 
     <!-- Favicons -->
     <link
@@ -101,26 +101,26 @@
   <body>
     <main>
       <button
-        aria-label="Activate Dark Mode"
-        title="Toggle Dark Mode"
+        aria-label="Ativar Modo Escuro"
+        title="Alternar Modo Escuro"
         aria-pressed="false"
         onclick="toggleTheme(this)"
         class="dark-mode-toggle"
       >
         <span class="sun">
           <img
-            alt="sun icon that represents light mode"
+            alt="ícone do sol que representa o modo claro"
             width="35px"
             src="images/sun.svg"
         /></span>
         <span class="moon"
           ><img
-            alt="moon icon to represent dark mode "
+            alt="ícone da lua para representar o modo escuro"
             width="25px"
             src="images/moon.svg"
         /></span>
       </button>
-      <h1>Text to Handwriting</h1>
+      <h1>Texto para Caligrafia</h1>
       <section class="generate-image-section">
         <br /><br />
         <form id="generate-image-form">
@@ -128,8 +128,8 @@
           <div class="display-flex output-grid responsive-flex">
             <div class="flex-1 page-container-super">
               <div>
-                <h2 style="margin-top: 0px;">Input</h2>
-                <label class="block" for="note">Type/Paste text here</label>
+                <h2 style="margin-top: 0px;">Entrada</h2>
+                <label class="block" for="note">Digite/cole o texto aqui</label>
               </div>
 
               <div class="flex-1 page-container">
@@ -170,7 +170,7 @@
                   style="font-size: 0.9rem; margin-top: 5px;"
                   class="draw-button"
                 >
-                  Draw <small>(Beta)</small>
+                  Desenhar <small>(Beta)</small>
                 </button>
               </div>
             </div>
@@ -178,21 +178,21 @@
             <div class="customization-col">
               <!-- Handwriting Font -->
               <div style="padding: 5px 0px 5px 0px;">
-                <b>Customizations</b> <small>(Optional)</small>
+                <b>Personalizações</b> <small>(Opcional)</small>
                 <p style="font-size: 0.8rem;">
                   <em
-                    >Note: Few changes may reflect only in the generated image
-                    and not in the preview</em
+                    >Observação: Poucas alterações podem refletir apenas na imagem gerada
+                    e não na visualização</em
                   >
                 </p>
               </div>
               <fieldset>
-                <legend>Handwriting Options</legend>
+                <legend>Opções de Caligrafia</legend>
 
                 <div class="category-grid">
                   <div>
                     <label class="block" for="handwriting-font"
-                      >Handwriting Font</label
+                      >Fonte de Caligrafia</label
                     >
                     <select id="handwriting-font">
                       <option
@@ -222,10 +222,10 @@
                   </div>
                   <div class="upload-handwriting-container">
                     <label class="block" for="font-file"
-                      >Upload your handwriting font <small>(Beta)</small>&nbsp;
+                      >Envie sua fonte de caligrafia <small>(Beta)</small>&nbsp;
                       <a
                         style="font-size: 1.1rem;"
-                        title="How to add your own handwriting"
+                        title="Como adicionar sua própria caligrafia"
                         href="#how-to-add-handwriting"
                       >
                         &#9432;
@@ -238,11 +238,11 @@
 
               <!-- Pen ink color, Font size, Vertical position text, Word Spacing -->
               <fieldset>
-                <legend>Page & Text Options</legend>
+                <legend>Opções de Página e Texto</legend>
 
                 <div class="category-grid">
                   <div class="postfix-input" data-postfix="pt">
-                    <label for="font-size">Font Size</label>
+                    <label for="font-size">Tamanho da Fonte</label>
                     <input
                       id="font-size"
                       min="0"
@@ -252,50 +252,50 @@
                     />
                   </div>
                   <div>
-                    <label class="block" for="ink-color">Ink Color</label>
+                    <label class="block" for="ink-color">Cor da Tinta</label>
                     <select id="ink-color">
-                      <option default value="#000f55">Blue</option>
-                      <option value="black">Black</option>
-                      <option value="#ba3807">Red</option>
+                      <option default value="#000f55">Azul</option>
+                      <option value="black">Preto</option>
+                      <option value="#ba3807">Vermelho</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block" for="page-size">Page Size</label>
+                    <label class="block" for="page-size">Tamanho da Página</label>
                     <select id="page-size">
                       <option default value="a4">A4 &nbsp;</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block" for="page-effects">Effects</label>
+                    <label class="block" for="page-effects">Efeitos</label>
                     <select id="page-effects">
-                      <option default value="shadows">Shadows</option>
+                      <option default value="shadows">Sombras</option>
                       <option value="scanner">Scanner</option>
-                      <option value="no-effect">No Effect</option>
+                      <option value="no-effect">Sem Efeito</option>
                     </select>
                   </div>
                   <div>
-                    <label class="block" for="resolution">Resolution</label>
+                    <label class="block" for="resolution">Resolução</label>
                     <select id="resolution">
-                      <option value="0.8">Very Low</option>
-                      <option value="1">Low</option>
+                      <option value="0.8">Muito Baixa</option>
+                      <option value="1">Baixa</option>
                       <option selected value="2">Normal</option>
-                      <option value="3">High</option>
-                      <option value="4">Very High</option>
+                      <option value="3">Alta</option>
+                      <option value="4">Muito Alta</option>
                     </select>
                   </div>
                 </div>
               </fieldset>
 
               <fieldset>
-                <legend>Spacing Options</legend>
+                <legend>Opções de Espaçamento</legend>
 
                 <div class="category-grid">
                   <div class="postfix-input" data-postfix="px">
-                    <label for="top-padding">Vertical Position</label>
+                    <label for="top-padding">Posição Vertical</label>
                     <input id="top-padding" min="0" value="5" type="number" />
                   </div>
                   <div class="postfix-input" data-postfix="px">
-                    <label for="word-spacing">Word Spacing</label>
+                    <label for="word-spacing">Espaçamento entre Palavras</label>
                     <input
                       id="word-spacing"
                       min="0"
@@ -305,7 +305,7 @@
                     />
                   </div>
                   <div class="postfix-input" data-postfix="pt">
-                    <label for="letter-spacing">Letter Spacing</label>
+                    <label for="letter-spacing">Espaçamento entre Letras</label>
                     <input
                       id="letter-spacing"
                       min="-5"
@@ -319,21 +319,21 @@
 
               <!-- Letter spacing, Paper Margin, Paper Lines, Paper Curvature -->
               <fieldset>
-                <legend>Margin & Line Options</legend>
+                <legend>Opções de Margem e Linha</legend>
 
                 <div class="category-grid">
                   <div>
                     <label for="paper-margin-toggle"
-                      >Paper Margin:
-                      <span aria-label="paper margin status" class="status"
-                        >on</span
+                      >Margem do Papel:
+                      <span aria-label="status da margem do papel" class="status"
+                        >ligado</span
                       >
                     </label>
                     <label class="switch-toggle outer">
                       <input
                         aria-checked="true"
                         checked
-                        aria-label="Paper Margin Button"
+                        aria-label="Botão de Margem do Papel"
                         id="paper-margin-toggle"
                         type="checkbox"
                       />
@@ -343,16 +343,16 @@
 
                   <div>
                     <label for="paper-line-toggle"
-                      >Paper Lines:
-                      <span aria-label="paper line status" class="status"
-                        >on</span
+                      >Linhas do Papel:
+                      <span aria-label="status da linha do papel" class="status"
+                        >ligado</span
                       >
                     </label>
                     <label class="switch-toggle outer">
                       <input
                         aria-checked="true"
                         checked
-                        aria-label="Paper Line Button"
+                        aria-label="Botão de Linha do Papel"
                         id="paper-line-toggle"
                         type="checkbox"
                       />
@@ -363,7 +363,7 @@
                     <!-- Removed option -->
                     <div class="upload-paper-container">
                       <label class="block" for="paper-file"
-                        >Upload Paper Image as Background</label
+                        >Carregar Imagem do Papel como Fundo</label
                       >
                       <input
                         accept=".jpg, .jpeg, .png"
@@ -388,7 +388,7 @@
                   data-testid="generate-image-button"
                   class="button generate-image-button"
                 >
-                  Generate Image
+                  Gerar Imagem
                 </button>
               </div>
             </div>
@@ -398,59 +398,57 @@
 
       <!-- OUTPUT -->
       <section>
-        <h2 id="output-header">Output</h2>
+        <h2 id="output-header">Saída</h2>
         <div id="output" class="output" style="text-align: center;">
-          Click "Generate Image" Button to generate new image.
+          Clique no botão "Gerar Imagem" para gerar uma nova imagem.
         </div>
         <div style="text-align: center; padding: 30px;">
           <button class="imp-button" id="download-as-pdf-button">
-            Download All Images as PDF
+            Baixar Todas as Imagens como PDF
           </button>
           <button class="delete-button" id="delete-all-button">
-            Clear all images
+            Limpar todas as imagens
           </button>
         </div>
       </section>
 
       <section id="how-to-add-handwriting">
-        <h2>🤓 Guide to add your own handwriting</h2>
+        <h2>🤓 Guia para adicionar sua própria caligrafia</h2>
         <div>
           <ul>
             <li>
-              To use your handwriting, you will have to generate font of your
-              handwriting.
+              Para usar sua caligrafia, você terá que gerar uma fonte da sua
+              caligrafia.
             </li>
             <li>
-              There are websites like
+              Existem sites como
               <a
                 target="_blank"
                 rel="noopener noreferrer"
                 href="https://www.calligraphr.com/en/"
                 >Calligraphr</a
               >
-              that let you do that.
+              que permitem que você faça isso.
             </li>
             <li>
-              Once you get .ttf file of your handwriting, upload it from 'Upload
-              your handwriting font' button in customizations sections
+              Depois de obter o arquivo .ttf da sua caligrafia, carregue-o a partir do botão 'Envie sua fonte de caligrafia' nas seções de personalizações
             </li>
           </ul>
         </div>
       </section>
 
       <section id="sponsors">
-        <h2>🤗 Sponsors</h2>
+        <h2>🤗 Patrocinadores</h2>
         <p>
-          This tool is completely free and neither stores any of your data for
-          money so maybe you can consider being patron or making an one time
-          payment with buy me a coffee to help the creator 🤗
+          Esta ferramenta é totalmente gratuita e não armazena nenhum dos seus dados por
+          dinheiro, então talvez você possa considerar ser um patrono ou fazer um pagamento único com o buy me a coffee para ajudar o criador 🤗
         </p>
         <p>
           <a href="https://www.patreon.com/bePatron?u=31891872">
             <img
               loading="lazy"
               style="border-radius: 4px;"
-              alt="Buy me a Coffee Button"
+              alt="Botão Compre-me um Café"
               width="200"
               src="https://c5.patreon.com/external/logo/become_a_patron_button.png"
             />
@@ -460,7 +458,7 @@
             <img
               loading="lazy"
               style="border-radius: 4px;"
-              alt="Buy me a Coffee Button"
+              alt="Botão Compre-me um Café"
               width="200"
               src="https://cdn.buymeacoffee.com/buttons/default-yellow.png"
             />
@@ -469,25 +467,25 @@
       </section>
 
       <section id="github-contributors">
-        <h2>👫 GitHub Contributors</h2>
+        <h2>👫 Contribuidores do GitHub</h2>
         <div class="project-contributors" id="project-contributors"></div>
       </section>
 
       <section id="faq">
-        <h2>❓ FAQs (Frequently Asked Questions)</h2>
+        <h2>❓ FAQs (Perguntas Frequentes)</h2>
         <div>
-          <h3>1. How can I add my own Handwriting?</h3>
+          <h3>1. Como posso adicionar minha própria caligrafia?</h3>
           <p>
-            Check out
+            Confira o
             <a href="#how-to-add-handwriting"
-              >Guide to add your own Handwriting</a
+              >Guia para adicionar sua própria caligrafia</a
             >
           </p>
         </div>
         <div>
-          <h3>2. Where can I get more fonts?</h3>
+          <h3>2. Onde posso conseguir mais fontes?</h3>
           <p>
-            You can use fonts from
+            Você pode usar fontes de
             <a
               href="https://www.quantumenterprises.co.uk/handwriting-fonts/fontvault.htm"
               >https://www.quantumenterprises.co.uk/handwriting-fonts/fontvault.htm</a
@@ -495,33 +493,33 @@
           </p>
         </div>
         <div>
-          <h3>3. There are gaps between letters in custom fonts</h3>
+          <h3>3. Existem lacunas entre as letras nas fontes personalizadas</h3>
           <p>
-            This is a known issue that we haven't figured out the solution for.
-            As a temporary workaround, there is letter spacing and word spacing
-            option to adjust the gap.
+            Este é um problema conhecido para o qual não descobrimos a solução.
+            Como uma solução temporária, existe a opção de espaçamento entre letras e palavras
+            para ajustar o espaço.
           </p>
         </div>
         <div>
-          <h3>4. Where can I request for features and report bugs?</h3>
+          <h3>4. Onde posso solicitar recursos e relatar bugs?</h3>
           <p>
-            You can't. This is a read-only project and there will not be any
-            improvements in the project
+            Você não pode. Este é um projeto somente leitura e não haverá
+            melhorias no projeto
           </p>
         </div>
       </section>
     </main>
     <footer style="padding: 40px 0px 10px 0px;">
-      Thank you for using Text to Handwriting! You can follow me on
+      Obrigado por usar o Texto para Caligrafia! Você pode me seguir no
       <a href="https://twitter.com/saurabhcodes">Twitter @saurabhcodes</a>
-      <br /><br />Do star the
+      <br /><br />Não se esqueça de estrelar o
       <a href="https://github.com/saurabhdaware/text-to-handwriting"
-        >Text-to-Handwriting GitHub Repository</a
+        >Repositório GitHub Texto-para-Caligrafia</a
       >
-      and If you're using it for writing assignments, make sure you use it at
-      your own risk and If it fails and your teacher finds this tool, ask them
-      to star my GitHub as well :D <br />
-      <br />byeeee! <br /><br />
+      e Se você estiver usando para fazer trabalhos, certifique-se de usá-lo por
+      sua conta e risco e Se falhar e seu professor encontrar esta ferramenta, peça a ele
+      para estrelar meu GitHub também :D <br />
+      <br />tchauzinho! <br /><br />
       ~ Saurabh (<a href="https://saurabhdaware.in">https://saurabhdaware.in</a
       >)
     </footer>
@@ -541,13 +539,13 @@
             id="add-to-paper-button"
             style="margin-top: 5px; margin-bottom: 5px;"
           >
-            Add to Paper
+            Adicionar ao Papel
           </button>
           <button
             id="draw-download-button"
             style="margin-top: 5px; margin-bottom: 5px;"
           >
-            Download Image
+            Baixar Imagem
           </button>
           <br /><br />
           <input
@@ -556,14 +554,14 @@
             accept="image/x-png,image/jpeg"
             hidden="hidden"
           />
-          <br /><br /><button id="add-new-image-button">Add bg image</button>
+          <br /><br /><button id="add-new-image-button">Adicionar imagem de fundo</button>
           <br /><br />
           <button
             id="clear-draw-canvas"
             class="blue-button"
             style="background-color: #f30; color: #fff;"
           >
-            Clear Canvas
+            Limpar Tela
           </button>
         </div>
       </div>
@@ -575,7 +573,7 @@
       rel="noopener noreferrer"
       target="_blank"
       class="github-corner"
-      aria-label="View source on GitHub"
+      aria-label="Ver código fonte no GitHub"
     >
       <svg
         width="80"
@@ -621,7 +619,7 @@
           window.localStorage.setItem('prefers-theme', 'light');
           if (toggleButton) {
             toggleButton.setAttribute('aria-pressed', false);
-            toggleButton.setAttribute('aria-label', 'Activate Dark Mode');
+            toggleButton.setAttribute('aria-label', 'Ativar Modo Escuro');
           }
         } else {
           document.body.classList.add('fade-in-dark');
@@ -630,7 +628,7 @@
           window.localStorage.setItem('prefers-theme', 'dark');
           if (toggleButton) {
             toggleButton.setAttribute('aria-pressed', true);
-            toggleButton.setAttribute('aria-label', 'Activate Light Mode');
+            toggleButton.setAttribute('aria-label', 'Ativar Modo Claro');
           }
         }
       }

--- a/js/app.mjs
+++ b/js/app.mjs
@@ -49,7 +49,7 @@ const EVENT_MAP = {
     on: 'change',
     action: (e) => {
       if (e.target.value > 30) {
-        alert('Font-size is too big try upto 30');
+        alert('O tamanho da fonte é muito grande, tente até 30');
       } else {
         setTextareaStyle('fontSize', e.target.value + 'pt');
         e.preventDefault();
@@ -60,7 +60,7 @@ const EVENT_MAP = {
     on: 'change',
     action: (e) => {
       if (e.target.value > 40) {
-        alert('Letter Spacing is too big try a number upto 40');
+        alert('O espaçamento entre letras é muito grande, tente um número até 40');
       } else {
         setTextareaStyle('letterSpacing', e.target.value + 'px');
         e.preventDefault();
@@ -71,7 +71,7 @@ const EVENT_MAP = {
     on: 'change',
     action: (e) => {
       if (e.target.value > 100) {
-        alert('Word Spacing is too big try a number upto hundred');
+        alert('O espaçamento entre palavras é muito grande, tente um número até cem');
       } else {
         setTextareaStyle('wordSpacing', e.target.value + 'px');
         e.preventDefault();
@@ -167,13 +167,13 @@ document.querySelectorAll('.switch-toggle input').forEach((toggleInput) => {
     if (toggleInput.checked) {
       document.querySelector(
         `label[for="${toggleInput.id}"] .status`
-      ).textContent = 'on';
+      ).textContent = 'ligado';
       toggleInput.setAttribute('aria-checked', true);
     } else {
       toggleInput.setAttribute('aria-checked', false);
       document.querySelector(
         `label[for="${toggleInput.id}"] .status`
-      ).textContent = 'off';
+      ).textContent = 'desligado';
     }
   });
 });


### PR DESCRIPTION
I applied `margin-left: auto;` and `margin-right: auto;` to the `.page-a` CSS rule to horizontally center the main text input area (the 'paper sheet').

This addresses an issue where the input paper might not appear centered, especially on wider screens. On narrower screens, it will be centered within its scrollable container.